### PR TITLE
return pids to wait from `launch_pipeline` via its `LaunchResult` ret…

### DIFF
--- a/src/execute/execute.c
+++ b/src/execute/execute.c
@@ -55,9 +55,10 @@ int wait_pipeline(t_pid_list* pids) // bad, should handle EINTR
 	return (status);
 }
 
-t_launch_result launch_pipeline(t_state *state, t_pipeline *pipeline, t_io ends, t_pid_list** pids)
+t_launch_result launch_pipeline(t_state *state, t_pipeline *pipeline, t_io ends)
 {
 	t_command current;
+	t_pid_list* pids_to_wait = NULL;
 
 	current = command_from_pipeline(pipeline);
 	while (current.type == PIPELINE_CMD)
@@ -81,7 +82,7 @@ t_launch_result launch_pipeline(t_state *state, t_pipeline *pipeline, t_io ends,
 
 		io_close(current_io);
 
-		pidl_push_back_link(pids, launch_result.pids); // bad might oom
+		pidl_push_back_link(&pids_to_wait, launch_result.pids); // bad might oom
 
 		fdl_clear(&fds_to_close);
 		current = current.pipeline->second;
@@ -89,9 +90,8 @@ t_launch_result launch_pipeline(t_state *state, t_pipeline *pipeline, t_io ends,
 	t_launch_result last = launch_simple_command(state, current.simple, ends, NULL);
 	io_close(ends);
 
-	pidl_push_back_link(pids, last.pids);
-
-	return (t_launch_result){.error = NO_ERROR}; // bad dummy
+	pidl_push_back_link(&pids_to_wait, last.pids); // bad may oom
+	return (t_launch_result){.error = NO_ERROR, .pids = pids_to_wait};
 }
 
 t_launch_result launch_simple_command(t_state *state, t_simple *simple, t_io io, t_fd_list **fds_to_close)
@@ -163,13 +163,11 @@ t_command_result execute_command(t_state *state, t_command command) {
 	}
 	else if (command.type == PIPELINE_CMD)
 	{
-		t_pid_list* pids = NULL;
-
 		t_launch_result launch_res;
-		launch_res = launch_pipeline(state, command.pipeline, io_default(), &pids);
+		launch_res = launch_pipeline(state, command.pipeline, io_default());
 		assert(launch_res.error == NO_ERROR); // bad, should handle launch error gracefully
 
-		int status = wait_pipeline(pids);
+		int status = wait_pipeline(launch_res.pids);
 		res = (t_command_result){.error = NO_ERROR, .status_code = status};
 	}
 	else if (command.type == CONDITIONAL_CMD)

--- a/src/execute/execute.h
+++ b/src/execute/execute.h
@@ -27,7 +27,7 @@ typedef struct s_command_result {
 
 // internals
 
-t_launch_result launch_pipeline(t_state *state, t_pipeline *pipeline, t_io io, t_pid_list** pids);
+t_launch_result launch_pipeline(t_state *state, t_pipeline *pipeline, t_io io);
 t_launch_result launch_simple_command(t_state *state, t_simple *simple, t_io io, t_fd_list **fds_to_close);
 
 // public

--- a/src/main.c
+++ b/src/main.c
@@ -36,13 +36,11 @@ t_error run_command(t_state *state, t_command cmd, int *status_out)
 	}
 	else if (cmd.type == PIPELINE_CMD)
 	{
-		t_pid_list* pids = NULL;
-
 		t_launch_result launch_res;
-		launch_res = launch_pipeline(state, cmd.pipeline, io_default(), &pids);
+		launch_res = launch_pipeline(state, cmd.pipeline, io_default());
 		assert(launch_res.error == NO_ERROR); // bad, should handle launch error gracefully
 
-		int status = wait_pipeline(pids);
+		int status = wait_pipeline(launch_res.pids);
 		res = (t_command_result){.error = NO_ERROR, .status_code = status};
 	}
 	else if (cmd.type == CONDITIONAL_CMD)


### PR DESCRIPTION
…urn, instead of via an out param (yucky)