### PR TITLE
directories are not executable

### DIFF
--- a/src/execute/execute.c
+++ b/src/execute/execute.c
@@ -112,7 +112,7 @@ t_launch_result launch_pipeline(t_state *state, t_pipeline *pipeline, t_io ends)
 #define COMMAND_NOT_FOUND_EXIT_CODE 127
 #define NOT_EXECUTABLE_EXIT_CODE 126
 
-bool file_is_directory(const char *command_path)
+static bool file_is_directory(const char *command_path)
 {
 	struct stat command_stats;
 	if (stat(command_path, &command_stats) < 0)

--- a/src/word/expansions/pathname/expand.c
+++ b/src/word/expansions/pathname/expand.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 static void ft_split_destroy(char *data[])
 {
@@ -46,8 +47,13 @@ typedef struct s_command_properties {
 	bool	is_executable;
 } t_command_properties;
 
-// from execute.c
-bool file_is_directory(const char *command_path);
+static bool file_is_directory(const char *command_path)
+{
+	struct stat command_stats;
+	if (stat(command_path, &command_stats) < 0)
+		return false;
+	return (S_ISDIR(command_stats.st_mode));
+}
 
 static t_error find_command_in_path(const char *path, const char *filename, t_command_properties *out)
 {

--- a/src/word/expansions/pathname/expand.c
+++ b/src/word/expansions/pathname/expand.c
@@ -46,6 +46,9 @@ typedef struct s_command_properties {
 	bool	is_executable;
 } t_command_properties;
 
+// from execute.c
+bool file_is_directory(const char *command_path);
+
 static t_error find_command_in_path(const char *path, const char *filename, t_command_properties *out)
 {
 	char *candidate;
@@ -55,7 +58,7 @@ static t_error find_command_in_path(const char *path, const char *filename, t_co
 	if (!candidate)
 		return (E_OOM);
 	p = (t_command_properties){0};
-	p.is_executable = access(candidate, X_OK) == 0;
+	p.is_executable = (access(candidate, X_OK) == 0) && !file_is_directory(candidate);
 	p.full_path = candidate;
 	*out = p;
 	return (NO_ERROR);


### PR DESCRIPTION
fix test case `Interpretation_Expansion_EmptyExpansionString`

```
Testing Interpretation_Expansion_EmptyExpansionString
    For command: "$HOMEdskjhfkdshfsd"
    Expected status 127 was 126
    Stderr doesnt contain pattern 'command not found'
stderr
minishell: /Users/poss/.opam/default/bin/: is a directory
stdout
✗   Interpretation_Expansion_EmptyExpansionString failed
```